### PR TITLE
make variable opt available in less.hbs

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ var getTemplate = function () {
 var transform = Promise.method(function (layouts, source, opt, Handlebars) {
   var template = Handlebars.compile(source);
   return template({
-    layouts: layouts
+    layouts: layouts,
+    opt: opt
   });
 });
 


### PR DESCRIPTION
The template less.hbs checks if opt.split is true but the options are not available in the template.
This PR passes the options object into the templating function 
