### PR TITLE
Enable access to options object in custom templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,12 @@ var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs-extra'));
 var path = require('path');
 
-var getTemplate = function () {
-  return fs.readFileAsync(path.join(__dirname, 'template', 'less.hbs'), 'utf8');
+var getTemplate = function (opt) {
+  if(opt.template){
+    return fs.readFileAsync(path.join(process.cwd(), opt.template), 'utf8');
+  }else{
+    return fs.readFileAsync(path.join(__dirname, 'template', 'less.hbs'), 'utf8');
+  }
 };
 
 var transform = Promise.method(function (layouts, source, opt, Handlebars) {
@@ -18,7 +22,7 @@ var transform = Promise.method(function (layouts, source, opt, Handlebars) {
 
 module.exports = {
   process: function (layouts, opt, Handlebars) {
-    return getTemplate()
+    return getTemplate(opt)
       .then(function (source) {
         return transform(layouts, source, opt, Handlebars);
       });


### PR DESCRIPTION
I needed to access the options object in a custom spritey-less template.
[This sprity issue](https://github.com/sprity/sprity/issues/20) said it's not possible, and after a little hacking it didn't seem worth the effort of doing it in sprity, and it proved much easier in sprity-less.

It still doesn't handle the handlebars tabs as well as when processing the default template, but it's much better than overwriting the default template file, as that is outside of the development repo.

Uses process.cwd() to compile the template filename, so paths should be relative to your project root.

```
gulp.task('sprites', function() {
    log('Compiling png sprites');
    return sprity.src({
        [other options]
        template: './src/sprity_template/less.hbs',
        processor: 'less'
    })
    .pipe(
        gulpif('*.png', gulp.dest(config.spritesBuild), gulp.dest(config.client + 'styles/sprites'))
    );
});
```
